### PR TITLE
Note on naming, reverse of fragment now made visible.

### DIFF
--- a/src/views/scrollver/components/fragment-card.vue
+++ b/src/views/scrollver/components/fragment-card.vue
@@ -2,9 +2,10 @@
     <div class="card">
         <router-link :to="{ path: `/fragment/${scrollVersionId}/${fragment.uniqueId}` }">
             <img class="card-img-top" v-lazy="imageUrl" v-if="imageUrl" alt="Fragment Image">
+            <--! This shows the back too -->
+            <img class="card-img-top" v-lazy="imageRevUrl" v-if="imageRevUrl" alt="Fragment Image">
         </router-link>
         <label>{{artefactsNames}}</label>
-        <img class="card-img-top" v-lazy="imageUrl" v-if="imageUrl" alt="Fragment Image">
     </div>
 </template>
 
@@ -13,7 +14,12 @@ import Vue from 'vue';
 import { Fragment } from '@/models/fragment';
 
 export default Vue.extend({
-    name: 'scroll-ver-fragments',
+    // This component had the same name as its parent.
+    // I would highly recommend ommitting the name attribute,
+    // then the component will take its name from its filename.
+    // I would also use the filename format FragmentCard.
+    // If you do this, then debugging with Vue Devtools becomes far easier.
+    name: 'scroll-ver-fragment-card',  
     props: {
         fragment: Fragment,
     },
@@ -21,6 +27,13 @@ export default Vue.extend({
         imageUrl(): string | undefined {
             if (this.fragment && this.fragment.recto && this.fragment.recto.master) {
                 return this.fragment.recto.master.getThumbnailUrl(600);
+            }
+            return undefined;
+        },
+        // Now we can see the back too.
+        imageRevUrl(): string | undefined {
+            if (this.fragment && this.fragment.verso && this.fragment.verso.master) {
+                return this.fragment.verso.master.getThumbnailUrl(600);
             }
             return undefined;
         },


### PR DESCRIPTION
I made a comment in the code about this, but perhaps we might discuss it a little bit here.  I noticed that the fragment-card.vue component had been given the name attribute "scroll-ver-fragments", which is certainly just a result of copy-paste.

I would suggest two changes.  If you do not declare a "name" attribute for the component, it will be taken from the filename.  I think this is preferable in order to avoid such mistakes.  Also, if you use camel case (with the initial letter also capital), then the automated name will perfectly match the filename.  This is pretty useful, since in Vue Devtools you get the component names and from that you can find the relevant file very quickly.  I leave it to you to decide what is easiest/clearest for you.

As for seeing the reverse of the fragment, perhaps this is useful too.  In any event, as you suggest the two should be treated together as a single unit.  I guess we will get feedback from the group whether they want to see the reverse of the image on the fragment viewer pane.