### PR TITLE
New artefact persists to database

### DIFF
--- a/src/views/fragment-editor/ArtefactCanvas.vue
+++ b/src/views/fragment-editor/ArtefactCanvas.vue
@@ -128,7 +128,7 @@ export default Vue.extend({
     },
   },
   methods: {
-    trackMouse(event: MouseEvent) {      
+    trackMouse(event: MouseEvent) {
       if (!this.selected) {
         return;
       }

--- a/src/views/fragment-editor/ImageMenu.vue
+++ b/src/views/fragment-editor/ImageMenu.vue
@@ -225,7 +225,10 @@ export default Vue.extend({
     },
     newArtefact() {
       const newArtefact = Artefact.createNew(this.scrollVersionId, this.fragment, this.newArtefactName);
-
+      console.log(this.artefact.sqeImageId);
+      newArtefact.sqeImageId = this.artefact.sqeImageId; // Somehow we lose sqeImageId from this.fragment
+      console.log(newArtefact.sqeImageId);
+      this.$emit('create', newArtefact);
       // waiting = false after artefact added
       this.newArtefactName = '';
     },
@@ -253,7 +256,8 @@ section {
   margin-bottom: 20px;
 }
 #image-menu {
-  height: 94vh;
+  height: 92vh;
+  overflow: auto;
 }
 button.disable {
   cursor: not-allowed;

--- a/src/views/fragment-editor/ImageMenu.vue
+++ b/src/views/fragment-editor/ImageMenu.vue
@@ -225,9 +225,7 @@ export default Vue.extend({
     },
     newArtefact() {
       const newArtefact = Artefact.createNew(this.scrollVersionId, this.fragment, this.newArtefactName);
-      console.log(this.artefact.sqeImageId);
       newArtefact.sqeImageId = this.artefact.sqeImageId; // Somehow we lose sqeImageId from this.fragment
-      console.log(newArtefact.sqeImageId);
       this.$emit('create', newArtefact);
       // waiting = false after artefact added
       this.newArtefactName = '';


### PR DESCRIPTION
Add new artefact now persists to the database.  The problem you were having is that I failed to let you know that an artefact must have an artefact_position for it to be returned as part of a scroll_version using the current API.  So I added the functionality that sets a position for the newly created artefact.

I apologize if I have not followed the idiom perfectly in my additions.  I trust that you can make the necessary changes, then I will be able to better understand the structure you prefer.  Thank you.

You will find one hack on line 228 of ImageMenu.vue.  It seems the fragment object never has, or somehow looses, the sqeImageId, which is needed when creating a new artefact in the database, so I copy it now from the existing artefact.  I wouldn't spend too much time on that problem right now, since some updates to the database will change the way we set the sqeImageId for each artefact.