### PR TITLE
Add comments to SignInterpretations

### DIFF
--- a/src/components/sign-attributes/sign-attribute-modal.vue
+++ b/src/components/sign-attributes/sign-attribute-modal.vue
@@ -230,6 +230,15 @@ export default class SignAttributeModal extends Vue {
     private onHide() {
         this.$state.artefactEditor.selectedAttribute = null;
     }
+
+    @Watch('attribute')
+    private onAttributeChanged() {
+        // The attribute can be deleted by another user
+        if (!this.attribute) {
+            this.hide();
+            this.$toasted.info(this.$tc('toasts.attributeDeletedBySomeoneElse'));
+        }
+    }
 }
 </script>
 

--- a/src/components/sign-attributes/sign-attribute-modal.vue
+++ b/src/components/sign-attributes/sign-attribute-modal.vue
@@ -39,7 +39,6 @@
                         class="inputsm"
                         type="search"
                         v-model="comment"
-                        @update="onCommentUpdated"
                         placeholder="Comment"
                     />
                 </b-col>
@@ -63,6 +62,7 @@ import {
     InterpretationAttributeDTO,
 } from '@/dtos/sqe-dtos';
 import { TextFragmentAttributeOperation } from '@/views/artefact-editor/operations';
+import { BvModalEvent } from 'bootstrap-vue';
 import { Component, Vue, Watch } from 'vue-property-decorator';
 import SignAttributeBadge from './sign-attribute-badge.vue';
 // import ErrorService from '@/services/error';
@@ -74,15 +74,41 @@ import SignAttributeBadge from './sign-attribute-badge.vue';
     },
 })
 export default class SignAttributeModal extends Vue {
-    private comment: string = '';
     private selected: string | null = null;
-
-    private mounted() {
-        this.setComment(this.attribute);
-    }
 
     private get attribute() {
         return this.$state.artefactEditor.selectedAttribute;
+    }
+
+    private get comment() {
+        if (this.isMultiSelect) {
+            return '';
+        }
+        return this.attribute?.commentary?.commentary || '';
+    }
+
+    private set comment(val: string) {
+        if (!this.attribute || this.isMultiSelect) {
+            console.warn("Can't set comment without an attribute or with multi selection");
+            return;
+        }
+
+        const si = this.$state.artefactEditor.selectedSignsInterpretation[0]; // Only one element, since !isMultiSelect
+        const newAttr: InterpretationAttributeDTO = { ...this.attribute! };
+
+        newAttr.commentary = val
+            ? ({ commentary: val } as CommentaryDTO)
+            : undefined;
+
+        // Create an operation that will be added to the undo/redo management of the artefact editor
+        const op = new TextFragmentAttributeOperation(
+            si.id,
+            this.attribute!.attributeValueId,
+            newAttr
+        );
+
+        op.redo(); // Apply change
+        this.$state.eventBus.emit('new-operation', op);
     }
 
     private get deleteAllowed() {
@@ -156,47 +182,6 @@ export default class SignAttributeModal extends Vue {
         }
 
         return description;
-    }
-
-    @Watch('attribute')
-    private onAttributeChanged(
-        newAttribute: InterpretationAttributeDTO | null
-    ) {
-        this.setComment(newAttribute);
-    }
-
-    /*    private onAttributeValueChanged(newVal: ) {
-        for (const si of this.$state.artefactEditor
-    } */
-
-    private setComment(newAttribute: InterpretationAttributeDTO | null) {
-        this.comment = newAttribute?.commentary?.commentary || '';
-    }
-
-    private onCommentUpdated() {
-        if (this.isMultiSelect) {
-            console.warn(
-                "Can't update a comment when multiple signs are selected"
-            );
-            return;
-        }
-
-        const si = this.$state.artefactEditor.selectedSignsInterpretation[0]; // Only one element, since !isMultiSelect
-        const newAttr: InterpretationAttributeDTO = { ...this.attribute! };
-
-        newAttr.commentary = this.comment
-            ? ({ commentary: this.comment } as CommentaryDTO)
-            : undefined;
-
-        // Create an operation that will be added to the undo/redo management of the artefact editor
-        const op = new TextFragmentAttributeOperation(
-            si.id,
-            this.attribute!.attributeValueId,
-            newAttr
-        );
-
-        op.redo(); // Apply change
-        this.$state.eventBus.emit('new-operation', op);
     }
 
     private onDeleteAttribute() {

--- a/src/components/sign-attributes/sign-attribute-pane.vue
+++ b/src/components/sign-attributes/sign-attribute-pane.vue
@@ -50,12 +50,26 @@
                 />
             </li>
         </ul>
+        <b-row v-if="!isMultiSelect" class="mt-3">
+            <b-col cols="3">
+                <label for="comment">Comment</label>
+            </b-col>
+            <b-col cols="9">
+                <b-form-input
+                    id="comment"
+                    class="inputsm"
+                    type="search"
+                    v-model="comment"
+                    placeholder="Comment"
+                />
+            </b-col>
+        </b-row>
         <sign-attribute-modal />
     </div>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
+import { Component, Vue, Watch } from 'vue-property-decorator';
 import { SignInterpretation } from '@/models/text';
 import {
     AttributeDTO,
@@ -64,7 +78,7 @@ import {
 } from '@/dtos/sqe-dtos';
 import SignAttribute from './sign-attribute.vue';
 import SignAttributeModal from './sign-attribute-modal.vue';
-import { TextFragmentAttributeOperation } from '@/views/artefact-editor/operations';
+import { SignInterpretationCommentOperation, TextFragmentAttributeOperation } from '@/views/artefact-editor/operations';
 import { BDropdown, BvEvent } from 'bootstrap-vue';
 
 @Component({
@@ -81,8 +95,29 @@ export default class SignAttributePane extends Vue {
     public get artefactEditor() {
         return this.$state.artefactEditor;
     }
+
     public get selectedSignsInterpretation(): SignInterpretation[] {
         return this.artefactEditor.selectedSignsInterpretation;
+    }
+
+    // The comment in the state.
+    private get comment(): string {
+        if (this.selectedSignsInterpretation.length !== 1) {
+            return '';
+        }
+
+        return this.selectedSignsInterpretation[0].commentary || '';
+    }
+
+    private set comment(val: string) {
+        if (this.selectedSignsInterpretation.length !== 1) {
+            console.warn("Can't change ta comment without one selected sign interperation");
+            return;
+        }
+
+        const op = new SignInterpretationCommentOperation(this.selectedSignsInterpretation[0].id, val);
+        op.redo();
+        this.$state.eventBus.emit('new-operation', op);
     }
 
     private get attributesMetadata() {
@@ -119,6 +154,12 @@ export default class SignAttributePane extends Vue {
             (attr) => attributeValues.includes(attr.attributeValueId)
         );
         return attributes;
+    }
+
+    private get isMultiSelect() {
+        return (
+            this.$state.artefactEditor.selectedSignsInterpretation.length !== 1
+        );
     }
 
     private onAttributeClick(attribute: InterpretationAttributeDTO) {

--- a/src/i18n/en/toasts.ts
+++ b/src/i18n/en/toasts.ts
@@ -28,7 +28,8 @@ export default {
 
     artefactDeleted: 'Artefact deleted',
     deleteArtefactFailed: 'Delete artefact failed',
-    artefactCantOverlap: "Artefact can't overlap other artefacts"
+    artefactCantOverlap: "Artefact can't overlap other artefacts",
 
+    attributeDeletedBySomeoneElse: 'Attribute was deleted by another user'
 };
 

--- a/src/i18n/fr/toasts.ts
+++ b/src/i18n/fr/toasts.ts
@@ -30,5 +30,6 @@ export default {
     deleteArtefactFailed: "Échec de la suppression de l'artefact",
     artefactCantOverlap: "L'artefact ne peut pas superposer d'autres artefacts"
 
+    // TODO: Translate attributeDeletedBySomeoneElse to French
 };
 

--- a/src/models/text.ts
+++ b/src/models/text.ts
@@ -152,6 +152,7 @@ class SignInterpretation {
     public attributes: InterpretationAttributeDTO[]; // InterpretationAttributeDTO[];
     public rois: InterpretationRoi[]; // InterpretationRoiDTO[];
     public nextSignInterpretations: NextSignInterpretationDTO[]; // NextSignInterpretationDTO[];
+    public commentary: string | null;
 
     public sign: Sign;
 
@@ -160,6 +161,7 @@ class SignInterpretation {
         this.character = obj.character;
         this.attributes = obj.attributes;
         this.nextSignInterpretations = obj.nextSignInterpretations;
+        this.commentary = obj.commentary?.commentary || null;
 
         if (obj.rois) {
             this.rois = obj.rois.map(roi => new InterpretationRoi(roi));

--- a/src/services/api-routes.ts
+++ b/src/services/api-routes.ts
@@ -145,4 +145,10 @@ export namespace ApiRoutes {
 
         return url;
     }
+
+    export function signInterpretationCommentaryUrl(editionId: number, signInterpretationId: number) {
+        const url = `v1/editions/${editionId}/sign-interpretations/${signInterpretationId}/commentary`;
+
+        return url;
+    }
 }

--- a/src/services/sign-interpretation.ts
+++ b/src/services/sign-interpretation.ts
@@ -3,7 +3,7 @@ import { StateManager } from '@/state';
 import { ApiRoutes } from '@/services/api-routes';
 import { EditionInfo } from '@/models/edition';
 import { SignInterpretation } from '@/models/text';
-import { InterpretationAttributeCreateDTO, InterpretationAttributeDTO, SignInterpretationDTO } from '@/dtos/sqe-dtos';
+import { CommentaryCreateDTO, InterpretationAttributeCreateDTO, InterpretationAttributeDTO, SignInterpretationDTO } from '@/dtos/sqe-dtos';
 
 export default class SignInterpretationService {
     public stateManager: StateManager;
@@ -43,7 +43,15 @@ export default class SignInterpretationService {
             commentary: attribute.commentary?.commentary
         };
 
-        const siDto = await CommHelper.post<SignInterpretationDTO>(url, dto);
-        return siDto;
+        const response = await CommHelper.post<SignInterpretationDTO>(url, dto);
+        return response.data;
+    }
+
+    public async updateCommentary(edition: EditionInfo, signInterpretation: SignInterpretation) {
+        const url = ApiRoutes.signInterpretationCommentaryUrl(edition.id, signInterpretation.id);
+        const dto: CommentaryCreateDTO = { commentary: signInterpretation.commentary || undefined };
+
+        const response = await CommHelper.put<SignInterpretationDTO>(url, dto);
+        return response.data;
     }
 }

--- a/src/state/notification-handler.ts
+++ b/src/state/notification-handler.ts
@@ -159,6 +159,18 @@ export class NotificationHandler {
         const selectedIndex = state().artefactEditor.selectedSignsInterpretation.findIndex(si => si.id === newSI.id);
         if (selectedIndex !== -1) {
             Vue.set(state().artefactEditor.selectedSignsInterpretation, selectedIndex, newSI);
+
+            // Update the selected attribute, too
+            const selectedAttribute = state().artefactEditor.selectedAttribute;
+            if (selectedAttribute) {
+                // Find the attribute in the new sign interpretation
+                const attrInNewSI = newSI.attributes.filter(attr => attr.attributeValueId === selectedAttribute.attributeValueId);
+                if (attrInNewSI.length === 1) {
+                    state().artefactEditor.selectedAttribute = attrInNewSI[0];
+                } else {
+                    state().artefactEditor.selectedAttribute = null;
+                }
+            }
         }
     }
 }

--- a/src/views/artefact-editor/artefact-editor.vue
+++ b/src/views/artefact-editor/artefact-editor.vue
@@ -212,6 +212,7 @@ import {
     ArtefactEditorOperation,
     ArtefactROIOperation,
     ArtefactRotateOperation,
+    SignInterpretationCommentOperation,
     TextFragmentAttributeOperation,
 } from './operations';
 import { SavingAgent, OperationsManager } from '@/utils/operations-manager';
@@ -287,6 +288,9 @@ export default class ArtefactEditor
                 ops.filter(
                     (op) => op.type === 'attr'
                 ) as TextFragmentAttributeOperation[]
+            );
+            await this.saveCommentaries(
+                ops.filter(op => op.type === 'commentary') as SignInterpretationCommentOperation[]
             );
         } catch (e) {
             console.error("Can't save arterfacts to server", e);
@@ -843,6 +847,17 @@ export default class ArtefactEditor
                     );
                     break;
             }
+        }
+    }
+
+    private async saveCommentaries(ops: SignInterpretationCommentOperation[]) {
+        for (const op of ops) {
+            const si = this.$state.signInterpretations.get(op.signInterpretationId);
+            if (!si) {
+                console.warn("Can't save commentary for non existing sign interpretation id ", op.signInterpretationId);
+                continue;
+            }
+            await this.signInterpretationService.updateCommentary(this.$state.editions.current!, si);
         }
     }
 


### PR DESCRIPTION
In this PR I have added the handling for sign interpretation comments.

I have also simplified the bindings of a comment (sign interpretation or attribute) - along the lines of your comments from yesterday's PR. Comments are now bound directly to the state (well, almost directly, I've placed setters to create the proper Operation, so updates can be undone).

A bug was also fixed, updates to the currently selected attribute were not reflected in the modal, since the selected attribute state did not update.