### PR TITLE
WYSIYWG editor for comments

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
 VUE_APP_MODE = development
 VUE_APP_BACKEND_PREFIX = http://localhost:8080
 VUE_APP_SIGNALR_URL = http://localhost:5000/signalr
+VUE_APP_TINYMCY_API_KEY = 5pachj4m91b2w0cj4mwunp79l9wg8wcqgky7xvzjdl43wpbt

--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,3 @@
 VUE_APP_MODE = development
 VUE_APP_BACKEND_PREFIX = http://localhost:8080
 VUE_APP_SIGNALR_URL = http://localhost:5000/signalr
-VUE_APP_TINYMCY_API_KEY = 5pachj4m91b2w0cj4mwunp79l9wg8wcqgky7xvzjdl43wpbt

--- a/cypress.json
+++ b/cypress.json
@@ -6,6 +6,6 @@
         "scroll_spec.js",
         "rename_editor_spec.js",
         "language_spec.js"
-
-    ]
+    ],
+    "defaultCommandTimeout": 10000
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
     sqe-http:
         container_name: SQE_HTTP_API
-        image: qumranica/sqe-http-api:0.6.5-pre2
+        image: qumranica/sqe-http-api:0.7.0-pre3
         restart: always
         ports:
             - 5000:5000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
     sqe-http:
         container_name: SQE_HTTP_API
-        image: qumranica/sqe-http-api:0.6.5-pre1
+        image: qumranica/sqe-http-api:0.6.5-pre2
         restart: always
         ports:
             - 5000:5000

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "devDependencies": {
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
         "@babel/plugin-proposal-optional-chaining": "^7.8.3",
+        "@tinymce/tinymce-vue": "^3.2.3",
         "@types/vue2-hammer": "^2.1.0",
         "@vue/cli-plugin-babel": "~4.2.2",
         "@vue/cli-plugin-typescript": "~4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sqe-scroll-editor",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "private": true,
     "scripts": {
         "serve": "vue-cli-service serve --mode development",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "mailslurp-client": "^8.7.8",
         "node-sass": "^4.14.0",
         "sass-loader": "^8.0.0",
-        "typescript": "~3.7.5",
+        "typescript": "^4.0.0",
         "vue-template-compiler": "^2.6.10"
     }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
         "test": "cypress open"
     },
     "dependencies": {
+        "@ckeditor/ckeditor5-build-classic": "^23.0.0",
+        "@ckeditor/ckeditor5-vue": "^1.0.3",
         "@fortawesome/fontawesome-svg-core": "^1.2.7",
         "@fortawesome/free-brands-svg-icons": "^5.4.2",
         "@fortawesome/free-regular-svg-icons": "^5.4.2",
@@ -41,7 +43,6 @@
     "devDependencies": {
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
         "@babel/plugin-proposal-optional-chaining": "^7.8.3",
-        "@tinymce/tinymce-vue": "^3.2.3",
         "@types/vue2-hammer": "^2.1.0",
         "@vue/cli-plugin-babel": "~4.2.2",
         "@vue/cli-plugin-typescript": "~4.2.2",

--- a/src/components/comment/comment.vue
+++ b/src/components/comment/comment.vue
@@ -32,6 +32,7 @@
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
+// We use require because with imports webpack complains a lot.
 // tslint:disable-next-line
 const ClassicEditor = require('@ckeditor/ckeditor5-build-classic');
 

--- a/src/components/comment/comment.vue
+++ b/src/components/comment/comment.vue
@@ -3,16 +3,34 @@
         <b-col cols="3">
             <label for="comment">Comment</label>
         </b-col>
-        <b-col cols="9">
-            <b-form-input
-                id="comment"
-                class="inputsm"
-                type="search"
-                v-model="comment"
-                @update="onCommentUpdated"
-                placeholder="Comment"
-            />
+        <b-col cols="5">
+            <span class="sm" @click="onViewComment()">{{ commentDisplay }}</span>
         </b-col>
+        <b-col cols="4">
+            <b-button @click="onViewComment()" title="View Comment" :disabled="!comment">
+                <i class="fa fa-eye"/>
+            </b-button>
+            <b-button @click="onEditComment()" title="Edit Comment">
+                <i class="fa fa-edit"/>
+            </b-button>
+            <b-button @click="onDeleteComment()" title="Delete Comment" :disabled="!comment">
+                <i class="fa fa-trash"/>
+            </b-button>
+        </b-col>
+        <b-modal ref="viewCommentModalRef" id="viewCommentModal" title="Comment" hide-footer hide-header>
+            <div id="comment-view" v-html="comment">
+            </div>
+        </b-modal>
+        <b-modal ref="editCommentModalRef" id="editCommentModal" title="Comment" hide-footer hide-header>
+            <div id="comment-edit">
+                <b-form-textarea
+                    id="comment"
+                    v-model="comment"
+                    @update="onCommentUpdated"
+                    placeholder="Enter the comment..."
+                />
+            </div>
+        </b-modal>
     </b-row>
 </template>
 
@@ -31,6 +49,18 @@ export default class CommentComponent extends Vue {
 
     private comment: string = ''; // Use v-model to bind here, we can't use v-model to bind to the value property
 
+    private get commentDisplay() {
+        if (!this.comment) {
+            return 'None';
+        }
+
+        let shortened = this.comment.substring(0, 10);
+        if (this.comment.length > 10) {
+            shortened += '...';
+        }
+        return shortened;
+    }
+
     private mounted() {
         this.comment = this.value || '';
     }
@@ -43,5 +73,36 @@ export default class CommentComponent extends Vue {
     private onValueChanged() {
         this.comment = this.value || '';
     }
+
+    private onDeleteComment() {
+        this.comment = '';
+        this.onCommentUpdated();
+    }
+
+    private onViewComment() {
+        (this.$refs.viewCommentModalRef as any).show();
+        // this.$bvModal.show('viewCommentModal');
+    }
+
+    private onEditComment() {
+        (this.$refs.viewEditModalRef as any).show();
+        // this.$bvModal.show('editCommentModal');
+    }
 }
 </script>
+
+<style lang="scss" scoped>
+#comment-view {
+    min-height: 250px;
+}
+
+#comment-edit {
+    min-height: 300px;
+
+    #comment {
+        display: block;
+        box-sizing: border-box;
+        height: 100%;
+    }
+}
+</style>

--- a/src/components/comment/comment.vue
+++ b/src/components/comment/comment.vue
@@ -23,12 +23,7 @@
         </b-modal>
         <b-modal ref="editCommentModalRef" id="editCommentModal" title="Comment" hide-footer hide-header>
             <div id="comment-edit">
-                <b-form-textarea
-                    id="comment"
-                    v-model="comment"
-                    @update="onCommentUpdated"
-                    placeholder="Enter the comment..."
-                />
+                <ckeditor :editor="editor" v-model="comment" @input="onCommentUpdated" />
             </div>
         </b-modal>
     </b-row>
@@ -36,6 +31,9 @@
 
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+
+// tslint:disable-next-line
+const ClassicEditor = require('@ckeditor/ckeditor5-build-classic');
 
 @Component({
     name: 'comment',
@@ -48,6 +46,7 @@ export default class CommentComponent extends Vue {
     public value!: string;
 
     private comment: string = ''; // Use v-model to bind here, we can't use v-model to bind to the value property
+    private editor = ClassicEditor;
 
     private get commentDisplay() {
         if (!this.comment) {
@@ -85,7 +84,7 @@ export default class CommentComponent extends Vue {
     }
 
     private onEditComment() {
-        (this.$refs.viewEditModalRef as any).show();
+        (this.$refs.editCommentModalRef as any).show();
         // this.$bvModal.show('editCommentModal');
     }
 }

--- a/src/components/comment/comment.vue
+++ b/src/components/comment/comment.vue
@@ -1,0 +1,47 @@
+<template>
+    <b-row>
+        <b-col cols="3">
+            <label for="comment">Comment</label>
+        </b-col>
+        <b-col cols="9">
+            <b-form-input
+                id="comment"
+                class="inputsm"
+                type="search"
+                v-model="comment"
+                @update="onCommentUpdated"
+                placeholder="Comment"
+            />
+        </b-col>
+    </b-row>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+
+@Component({
+    name: 'comment',
+    components: {
+    },
+})
+export default class CommentComponent extends Vue {
+    // Follow the v-model pattern as described here: https://www.digitalocean.com/community/tutorials/vuejs-add-v-model-support
+    @Prop()
+    public value!: string;
+
+    private comment: string = ''; // Use v-model to bind here, we can't use v-model to bind to the value property
+
+    private mounted() {
+        this.comment = this.value || '';
+    }
+
+    private onCommentUpdated() {
+        this.$emit('input', this.comment);
+    }
+
+    @Watch('value')
+    private onValueChanged() {
+        this.comment = this.value || '';
+    }
+}
+</script>

--- a/src/components/sign-attributes/sign-attribute-modal.vue
+++ b/src/components/sign-attributes/sign-attribute-modal.vue
@@ -29,20 +29,7 @@
                 </b-col>
             </b-row>
 
-            <b-row v-if="!isMultiSelect" class="mt-3">
-                <b-col cols="3">
-                    <label for="comment">Comment</label>
-                </b-col>
-                <b-col cols="9">
-                    <b-form-input
-                        id="comment"
-                        class="inputsm"
-                        type="search"
-                        v-model="comment"
-                        placeholder="Comment"
-                    />
-                </b-col>
-            </b-row>
+            <comment v-if="!isMultiSelect" v-model="comment" class="mt-3" />
         </div>
         <template v-slot:modal-footer>
             <b-button :disabled="!deleteAllowed" @click="onDeleteAttribute">
@@ -64,6 +51,7 @@ import {
 import { TextFragmentAttributeOperation } from '@/views/artefact-editor/operations';
 import { BvModalEvent } from 'bootstrap-vue';
 import { Component, Vue, Watch } from 'vue-property-decorator';
+import CommentComponent from '../comment/comment.vue';
 import SignAttributeBadge from './sign-attribute-badge.vue';
 // import ErrorService from '@/services/error';
 
@@ -71,6 +59,7 @@ import SignAttributeBadge from './sign-attribute-badge.vue';
     name: 'sign-attribute-modal',
     components: {
         'sign-attribute-badge': SignAttributeBadge,
+        'comment': CommentComponent,
     },
 })
 export default class SignAttributeModal extends Vue {

--- a/src/components/sign-attributes/sign-attribute-modal.vue
+++ b/src/components/sign-attributes/sign-attribute-modal.vue
@@ -64,6 +64,7 @@ import SignAttributeBadge from './sign-attribute-badge.vue';
 })
 export default class SignAttributeModal extends Vue {
     private selected: string | null = null;
+    private hidingStarted = false;
 
     private get attribute() {
         return this.$state.artefactEditor.selectedAttribute;
@@ -216,17 +217,20 @@ export default class SignAttributeModal extends Vue {
     private hide() {
         (this.$refs.signAttributeModalRef as any).hide();
     }
+
     private onHide() {
+        this.hidingStarted = true;
         this.$state.artefactEditor.selectedAttribute = null;
     }
 
     @Watch('attribute')
     private onAttributeChanged() {
         // The attribute can be deleted by another user
-        if (!this.attribute) {
+        if (!this.attribute && !this.hidingStarted) {
             this.hide();
             this.$toasted.info(this.$tc('toasts.attributeDeletedBySomeoneElse'));
         }
+        this.hidingStarted = false;
     }
 }
 </script>

--- a/src/components/sign-attributes/sign-attribute-pane.vue
+++ b/src/components/sign-attributes/sign-attribute-pane.vue
@@ -105,7 +105,6 @@ export default class SignAttributePane extends Vue {
 
     // The comment in the state.
     private get comment(): string {
-        console.debug('comment getter called');
         if (this.selectedSignsInterpretation.length !== 1) {
             return '';
         }
@@ -114,7 +113,6 @@ export default class SignAttributePane extends Vue {
     }
 
     private set comment(val: string) {
-        console.debug('comment setter called', val);
         if (this.selectedSignsInterpretation.length !== 1) {
             console.warn("Can't change ta comment without one selected sign interperation");
             return;

--- a/src/components/sign-attributes/sign-attribute-pane.vue
+++ b/src/components/sign-attributes/sign-attribute-pane.vue
@@ -50,7 +50,7 @@
                 />
             </li>
         </ul>
-        <b-row v-if="!isMultiSelect" class="mt-3">
+        <!-- <b-row v-if="!isMultiSelect" class="mt-3">
             <b-col cols="3">
                 <label for="comment">Comment</label>
             </b-col>
@@ -63,7 +63,8 @@
                     placeholder="Comment"
                 />
             </b-col>
-        </b-row>
+        </b-row> -->
+        <comment v-model="comment" v-if="!isMultiSelect" class="mt-3" />
         <sign-attribute-modal />
     </div>
 </template>
@@ -80,12 +81,14 @@ import SignAttribute from './sign-attribute.vue';
 import SignAttributeModal from './sign-attribute-modal.vue';
 import { SignInterpretationCommentOperation, TextFragmentAttributeOperation } from '@/views/artefact-editor/operations';
 import { BDropdown, BvEvent } from 'bootstrap-vue';
+import CommentComponent from '../comment/comment.vue';
 
 @Component({
     name: 'sign-attribute-pane',
     components: {
         'sign-attribute-modal': SignAttributeModal,
         'sign-attribute': SignAttribute,
+        'comment': CommentComponent,
     },
 })
 export default class SignAttributePane extends Vue {
@@ -102,6 +105,7 @@ export default class SignAttributePane extends Vue {
 
     // The comment in the state.
     private get comment(): string {
+        console.debug('comment getter called');
         if (this.selectedSignsInterpretation.length !== 1) {
             return '';
         }
@@ -110,6 +114,7 @@ export default class SignAttributePane extends Vue {
     }
 
     private set comment(val: string) {
+        console.debug('comment setter called', val);
         if (this.selectedSignsInterpretation.length !== 1) {
             console.warn("Can't change ta comment without one selected sign interperation");
             return;

--- a/src/dtos/sqe-dtos.ts
+++ b/src/dtos/sqe-dtos.ts
@@ -169,14 +169,6 @@ export interface InterpretationAttributeDTO extends InterpretationAttributeBaseD
     commentary?: CommentaryDTO;
 }
 
-export interface InterpretationAttributeCreateListDTO {
-    attributes?: Array<InterpretationAttributeCreateDTO>;
-}
-
-export interface InterpretationAttributeListDTO {
-    attributes?: Array<InterpretationAttributeDTO>;
-}
-
 export interface CreateAttributeValueDTO {
     value: string;
     description?: string;
@@ -437,11 +429,6 @@ export interface DeleteTokenDTO {
     token: string;
 }
 
-export interface DeleteEditionEntityDTO {
-    entityId: number;
-    editorId: number;
-}
-
 export interface CommentaryCreateDTO {
     commentary?: string;
 }
@@ -575,8 +562,11 @@ export interface SetInterpretationRoiDTO {
     valuesSet: boolean;
 }
 
-export interface InterpretationRoiDTO extends SetInterpretationRoiDTO {
+export interface UpdateInterpretationRoiDTO extends SetInterpretationRoiDTO {
     interpretationRoiId: number;
+}
+
+export interface InterpretationRoiDTO extends UpdateInterpretationRoiDTO {
     creatorId: number;
     editorId: number;
 }
@@ -593,13 +583,17 @@ export interface InterpretationRoiDTOList {
     rois: Array<InterpretationRoiDTO>;
 }
 
+export interface UpdateInterpretationRoiDTOList {
+    rois: Array<UpdateInterpretationRoiDTO>;
+}
+
 export interface UpdatedInterpretationRoiDTOList {
     rois: Array<UpdatedInterpretationRoiDTO>;
 }
 
 export interface BatchEditRoiDTO {
-    createRois?: Array<InterpretationRoiDTO>;
-    updateRois?: Array<UpdatedInterpretationRoiDTO>;
+    createRois?: Array<SetInterpretationRoiDTO>;
+    updateRois?: Array<UpdateInterpretationRoiDTO>;
     deleteRois?: Array<number>;
 }
 

--- a/src/dtos/sqe-signalr.ts
+++ b/src/dtos/sqe-signalr.ts
@@ -37,8 +37,6 @@ import {
 	InterpretationAttributeBaseDTO,
 	InterpretationAttributeCreateDTO,
 	InterpretationAttributeDTO,
-	InterpretationAttributeCreateListDTO,
-	InterpretationAttributeListDTO,
 	CreateAttributeValueDTO,
 	UpdateAttributeValueDTO,
 	AttributeValueDTO,
@@ -84,7 +82,6 @@ import {
 	AdminEditorRequestListDTO,
 	TextEditionDTO,
 	DeleteTokenDTO,
-	DeleteEditionEntityDTO,
 	CommentaryCreateDTO,
 	CommentaryDTO,
 	DeleteDTO,
@@ -110,10 +107,12 @@ import {
 	ImagedObjectListDTO,
 	WktPolygonDTO,
 	SetInterpretationRoiDTO,
+	UpdateInterpretationRoiDTO,
 	InterpretationRoiDTO,
 	UpdatedInterpretationRoiDTO,
 	SetInterpretationRoiDTOList,
 	InterpretationRoiDTOList,
+	UpdateInterpretationRoiDTOList,
 	UpdatedInterpretationRoiDTOList,
 	BatchEditRoiDTO,
 	BatchEditRoiResponseDTO,
@@ -198,7 +197,7 @@ export class SignalRUtilities {
 	 * @param updateRois - A JSON object with an array of the updated ROI details
 	 *
 	 */
-    public async putV1EditionsEditionIdRoisBatch(editionId: number, updateRois: InterpretationRoiDTOList): Promise<UpdatedInterpretationRoiDTOList> {
+    public async putV1EditionsEditionIdRoisBatch(editionId: number, updateRois: UpdateInterpretationRoiDTOList): Promise<UpdatedInterpretationRoiDTOList> {
         return await this._connection.invoke('PutV1EditionsEditionIdRoisBatch', editionId, updateRois);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,10 @@ import { StateManager } from './state';
 // vue2-hammer
 import { VueHammer } from 'vue2-hammer';
 
+// tslint:disable-next-line
+const CKEditor = require('@ckeditor/ckeditor5-vue');
+
+
 // import AsyncComputed from 'vue-async-computed';
 
 Vue.config.productionTip = false;
@@ -69,6 +73,7 @@ Vue.use(VueShortcuts, { prevent: ['input'] });
 Vue.use(RenderingOptimizationPlugin);
 
 Vue.use(VueHammer);
+Vue.use(CKEditor);
 
 router.beforeEach((to, from, next) => {
   if (to.matched.some((record) => record.meta.activeUserRoute)) {

--- a/src/utils/VectorFactory.ts
+++ b/src/utils/VectorFactory.ts
@@ -304,73 +304,6 @@ export function geoJSONPolygonToWKT(geoJSON: any) {
 }
 
 /*
- * This function expects the transform matrix
- * to be in a 2D array: [[a,c,tx],[b,d,ty]].
- * It returns a transform matrix which can be
- * used in an SVG element.
- */
-export function dbMatrixToSVG(matrix: any) {
-  if (matrix.constructor === String && isJSON(matrix)) {
-    matrix = JSON.parse(matrix).matrix;
-  }
-  return matrix.length === 2 && matrix[0].length === 3 && matrix[1].length === 3
-    ? [matrix[0][0], matrix[1][0], matrix[0][1], matrix[1][1], matrix[0][2], matrix[1][2]]
-    : undefined;
-}
-
-/*
- * This function converts the 6 element SVG
- * transform matrix to a JSON string for the
- * 2D transform matrix as stored in the database.
- */
-export function svgMatrixToDB(matrix: any) {
-  return Array.isArray(matrix) && matrix.length === 6
-    ? `{"matrix": [[${matrix[0]},${matrix[2]},${matrix[4]}],[${matrix[1]},${matrix[3]},${
-        matrix[5]
-      }]]}`
-    : undefined;
-}
-
-/*
- * This function converts the 16 element 3D
- * SVG transform matrix to a 6 element 2D SVG
- * transform matrix.
- */
-export function matrix6To16(matrix: any) {
-  return Array.isArray(matrix) && matrix.length === 6
-    ? [
-        matrix[0],
-        matrix[1],
-        0,
-        0,
-        matrix[2],
-        matrix[3],
-        0,
-        0,
-        0,
-        0,
-        1,
-        0,
-        matrix[4],
-        matrix[5],
-        0,
-        1,
-      ]
-    : undefined;
-}
-
-/*
- * This function converts the 6 element 2D
- * SVG transform matrix to a 16 element 3D SVG
- * transform matrix.
- */
-export function matrix16To6(matrix: any) {
-  return Array.isArray(matrix) && matrix.length === 16
-    ? [matrix[0], matrix[1], matrix[4], matrix[5], matrix[12], matrix[13]]
-    : undefined;
-}
-
-/*
  * This function receives an HTML5 canvas
  * along with a svg path for the clipping mask
  * It then draws the svg path onto the canvas.
@@ -399,12 +332,4 @@ export function clipCanvas(canvas: HTMLCanvasElement, svgClipPath: string, fillC
   });
   ctx.closePath();
   ctx.fill();
-}
-
-function isJSON(str: string) {
-  try {
-    return JSON.parse(str) && !!str;
-  } catch (e) {
-    return false;
-  }
 }

--- a/src/views/artefact-editor/artefact-editor.vue
+++ b/src/views/artefact-editor/artefact-editor.vue
@@ -799,8 +799,6 @@ export default class ArtefactEditor
                     break;
             }
 
-            console.debug(`opType: ${opType}, existingIndex: ${existingIndex}, actualOpType: ${actualOpType}`);
-
             switch (actualOpType) {
                 case 'create':
                     await this.signInterpretationService.createAttribute(
@@ -821,10 +819,8 @@ export default class ArtefactEditor
                         return;
                     }
 
-                    console.debug(`Detected an update of an attributeValueId from ${op.prev.attributeValueId} to ${op.next.attributeValueId}`);
                     const prevIndex = si.findAttributeIndex(op.prev.attributeValueId);
                     const nextIndex = si.findAttributeIndex(op.next.attributeValueId);
-                    console.debug(`prevIndex ${prevIndex}, nextIndex ${nextIndex}`);
 
                     if (prevIndex !== -1 && nextIndex !== -1) {
                         console.error('In an attribute value update, we have both prev and next in the current attributes', op);

--- a/src/views/artefact-editor/operations.ts
+++ b/src/views/artefact-editor/operations.ts
@@ -173,17 +173,14 @@ export class TextFragmentAttributeOperation extends ArtefactEditorOperation {
 
         if (!this.prev) {
             if (existingIndex !== -1) {
-                console.debug('Undoing new attribute, removing item from index ', existingIndex);
                 this.signInterpretation.attributes.splice(existingIndex, 1);
             } else {
                 console.warn("Can't undo operation with no prev and no existing index");
             }
         } else {
             if (existingIndex !== -1) {
-                console.debug('Undoing update, setting index ', existingIndex, ' to ', this.prev, this.prev.commentary?.commentary);
                 Vue.set(this.signInterpretation.attributes, existingIndex, this.prev);
             } else {
-                console.debug('Undoing deletion, pushing ', this.prev, this.prev.commentary?.commentary);
                 this.signInterpretation.attributes.push(this.prev);
             }
         }
@@ -194,15 +191,12 @@ export class TextFragmentAttributeOperation extends ArtefactEditorOperation {
 
         if (this.next) {
             if (existingIndex !== -1) {
-                console.debug('Redoing update ', this.next, this.next.commentary?.commentary);
                 Vue.set(this.signInterpretation.attributes, existingIndex, this.next);
             } else {
-                console.debug('Redoing create ', this.next, this.next.commentary?.commentary);
                 this.signInterpretation.attributes.push(this.next);
             }
         } else {
             if (existingIndex !== -1) {
-                console.debug('Redoing deletion, Deleting from index ', existingIndex);
                 this.signInterpretation.attributes.splice(existingIndex, 1);
             } else {
                 console.warn("Can't redo operation with no next and no existingIndex");

--- a/yarn.lock
+++ b/yarn.lock
@@ -8548,10 +8548,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
 uglify-js@3.4.x:
   version "3.4.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,6 +863,16 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@ckeditor/ckeditor5-build-classic@^23.0.0":
+  version "23.0.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-23.0.0.tgz#9b4ae5dc470e9ae4be14672b49d05d21887e2d81"
+  integrity sha512-9Pgb9OAPnx1577WDYizEuOFHmLyXkwU8UxneyP4Zkr9mrJUEL0w0uVgQhiB8DYlAAArHXeFasSogwFvLX6xBtw==
+
+"@ckeditor/ckeditor5-vue@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-vue/-/ckeditor5-vue-1.0.3.tgz#b73babe217e222614f0567bf858de8152c2071b2"
+  integrity sha512-8pYcWkOSUTZ4KD6nT2JbD4rQycvhCaoOAJeOiaSrjWb3X/xRWoDEOOJzXC6VRk9AeNE1UYY9wKBAsq3VoR5V9w==
+
 "@cypress/listr-verbose-renderer@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#a77492f4b11dcc7c446a34b3e28721afd33c642a"
@@ -1032,11 +1042,6 @@
     chalk "^1.1.3"
     error-stack-parser "^2.0.0"
     string-width "^2.0.0"
-
-"@tinymce/tinymce-vue@^3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@tinymce/tinymce-vue/-/tinymce-vue-3.2.3.tgz#9fdde71bb00d37b9f53400047ff30a73803e598d"
-  integrity sha512-SMjpAQg2BLtYmnx4s3rKiAFxgXCx4uKWu8XmcvsZoYl5kvF4yaoqx70ovYJvT83ucpO7n6pewnQL3O4lR2WF3Q==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1033,6 +1033,11 @@
     error-stack-parser "^2.0.0"
     string-width "^2.0.0"
 
+"@tinymce/tinymce-vue@^3.2.3":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@tinymce/tinymce-vue/-/tinymce-vue-3.2.3.tgz#9fdde71bb00d37b9f53400047ff30a73803e598d"
+  integrity sha512-SMjpAQg2BLtYmnx4s3rKiAFxgXCx4uKWu8XmcvsZoYl5kvF4yaoqx70ovYJvT83ucpO7n6pewnQL3O4lR2WF3Q==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"


### PR DESCRIPTION
This pull request contains the addition of the CKEditor WYSIWYG  editor for editing comments. Comments are now edited in a popup that hosts the editor. The result is HTML markup.

The UI still needs work - make the editor the right size, decide exactly what appears in the toolbar (we don't want to add images, but perhaps we do want to support tables?), and figure out what to display in the attribute pane or modal when there is a comment (right now it's the beginning of the markup, which is not very nice).

I dropped TinyMCE since its Vue integration did not behave as documented. CKEditor was *a lot* easier to integrate, and provides everything we need. We also don't need an external service for this, it is all contained in our code.