### PR TITLE
Some cleanup and auto text display using suggestions

### DIFF
--- a/src/components/text/text-sign.vue
+++ b/src/components/text/text-sign.vue
@@ -180,10 +180,7 @@ span.highlighted {
 .text-sign::after {
     content: none;
 }
-.text-sign.is-reconstructed-true::after {
-    content: '\05C4';
-    /* Add a dot above the character */
-}
+
 .readability-incomplete-but-clear {
     /* readability-incomplete_but_clear */
     color: green;

--- a/src/dtos/sqe-dtos.ts
+++ b/src/dtos/sqe-dtos.ts
@@ -49,6 +49,7 @@ export interface TextFragmentDataDTO {
     id: number;
     name: string;
     editorId: number;
+    suggested: boolean;
 }
 
 export interface ArtefactTextFragmentMatchDTO extends TextFragmentDataDTO {

--- a/src/models/text.ts
+++ b/src/models/text.ts
@@ -20,11 +20,13 @@ class TextFragmentData {
     public id: number;
     public name: string;
     public editorId: number;
+    public suggested: boolean;
 
     constructor(obj: TextFragmentDataDTO) {
         this.id = obj.id;
         this.name = obj.name;
         this.editorId = obj.editorId;
+        this.suggested = obj.suggested;
     }
 }
 
@@ -34,7 +36,7 @@ class ArtefactTextFragmentData extends TextFragmentData {
             id: tf.id,
             name: tf.name,
             editorId: tf.editorId,
-            suggested: true
+            suggested: tf.suggested
         });
     }
     public certain: boolean;

--- a/src/services/api-routes.ts
+++ b/src/services/api-routes.ts
@@ -95,8 +95,8 @@ export namespace ApiRoutes {
         return `/${baseUrl}/${editions}/${editionId}/${textFragments}`;
     }
 
-    export function artefactTextFragmentsUrl(editionId: number, artefactId: number) {
-        return `${baseUrl}/${editions}/${editionId}/${artefacts}/${artefactId}/text-fragments`;
+    export function artefactTextFragmentsUrl(editionId: number, artefactId: number, suggestions: boolean = false) {
+        return `${baseUrl}/${editions}/${editionId}/${artefacts}/${artefactId}/text-fragments${suggestions ? '?optional=suggested' : ''}`;
     }
 
     export function editionTextFragmentUrl(editionId: number, textFragmentId: number) {

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -36,10 +36,24 @@ class TextService {
 
     public async getArtefactTextFragments(editionId: number, artefactId: number) {
         const response = await CommHelper.get<ArtefactTextFragmentMatchListDTO>(
-            ApiRoutes.artefactTextFragmentsUrl(editionId, artefactId)
+            ApiRoutes.artefactTextFragmentsUrl(editionId, artefactId, true)
         );
 
-        return response.data.textFragments.map(obj => new ArtefactTextFragmentData(obj));
+        /*
+         * NOTE: Bronson added some checking here to help in getting matches.
+         * There is logic further downstream to also do this kind of sorting.
+         * Make a decision whether to do it in both places, or perhaps to remove
+         * the "suggested" filter here (and just return all results).
+         */
+
+        // Check if there are any actual matches (not just suggested matches)
+        const actualMatches = response.data.textFragments.filter(x => x.suggested === false);
+        console.info(response.data.textFragments);
+
+        // If there are actual matches use only those, otherwise return everything
+        return actualMatches.length > 0 ?
+            actualMatches.map(obj => new ArtefactTextFragmentData(obj))
+            : response.data.textFragments.map(obj => new ArtefactTextFragmentData(obj));
     }
 
     public async getTextFragment(editionId: number, textFragmentId: number) {

--- a/src/state/artefact-editor.ts
+++ b/src/state/artefact-editor.ts
@@ -64,6 +64,7 @@ export class ArtefactEditorState {
                 name: siTextFragment.textFragmentName,
                 editorId: siTextFragment.editorId,
                 certain: true,
+                suggested: false,
             });
         } else {
             tf.certain = true;

--- a/src/views/home/components/EditionsList.vue
+++ b/src/views/home/components/EditionsList.vue
@@ -64,4 +64,13 @@ export default class EditionsList extends Vue {
     margin: 10px;
 }
 
+// NOTE: Bronson added this and it is probably not really good.
+// There will be two edition-lists in the window, and one
+// or the other may be collapsed.  The max height setting should
+// be dependent upon whether only one or both edition-lists
+// are opened.
+.afterlogin {
+    max-height: 35vh;
+    overflow: auto;
+}
 </style>

--- a/src/views/home/components/EditionsPublicList.vue
+++ b/src/views/home/components/EditionsPublicList.vue
@@ -55,4 +55,10 @@ export default class EditionsPublicList extends Vue {
     margin: 10px;
 }
 
+//NOTE: Bronson added this, and the height looks very good
+.afterlogin {
+    max-height: 75vh;
+    overflow: auto;
+}
+
 </style>


### PR DESCRIPTION
@zmbq **do not merge this PR.**  I just thought it would be easier for you to see diff things here.

I addressed three issues here:

1. A hack in the CSS of EditionsList.vue and EditionsPublicList.vue.  Ignore this, @shaindelb will do it properly (I just needed a quick fix for the demo today)
2. Updates to the approach to getting text fragments for an artefact.  You will see I added the "?optional=suggested" query parameter, this allows the API to send not only certain matches, but also matches that it thinks might be correct based on cataloguing info.  Then you will see a bunch of changes with some notes from me about displaying the suggested text fragment in cases where there is no certain match available.  Here is an example of the website finding matching text for an artefact based on a suggestion from the API: [https://qumranica.org/Scrollery/editions/905/artefacts/4809](https://qumranica.org/Scrollery/editions/905/artefacts/4809)
3. I allow unauthenticated users to select text for display in the artefact editor.  I think we want this.

Please check over the notes on points 2 and 3.  I am sure @shaindelb will take care of point 1 when she finds the time.